### PR TITLE
Add graceful shutdown for SIGTERM

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+import signal
 
 from flask import Flask
 from flask import render_template
@@ -62,6 +63,13 @@ def index():
         'sms_request_url': url_for('.sms', _external=True),
         'client_url': url_for('.client', _external=True)}
     return render_template('index.html', params=params)
+
+# Handles SIGTERM so that we don't get an error when Heroku wants or needs to restart the dyno
+def graceful_shutdown(signum, frame):
+    print "Rob Spectre is always graceful. So there."
+    exit()
+
+signal.signal(signal.SIGTERM, graceful_shutdown)
 
 
 # If PORT not specified by environment, assume development config.


### PR DESCRIPTION
...which Heroku tends to send now and then. (I guess mostly if the app is idle?)
Without this change, you get an error in the logs and if you have LogEntries installed for example, that means an email sent to you.

But really, it's mostly because I was just having the problem myself and to look like I know what I'm doing. :)
